### PR TITLE
fix: reliably connecting after 1 retry

### DIFF
--- a/src/screens/homeScreen.tsx
+++ b/src/screens/homeScreen.tsx
@@ -51,7 +51,7 @@ export const HomeScreen = () => {
       </BaseView>
       {currentCamera && (
         <BaseView className="flex-1">
-          <WebRTCView cameraName={currentCamera} />
+          <WebRTCView cameraName={currentCamera} key={currentCamera} />
           <BaseText>Viewing: {currentCamera}</BaseText>
         </BaseView>
       )}


### PR DESCRIPTION
Added proper setup and cleanup of necessary event listeners so to not have to do this every time we run the connect function.

Also ensure that we're creating new components for each individual camera as to not accidentally re-use old RTCPeerConnections or WebSockets.

This seems to make it so that on the second retry attempt we have about 95% successful connection rate. This leads me to believe that we're still not doing something entirely correctly which is what is causing the inconsistency.

This also still only works over a local network connection, which will have to be addressed at some point.