### PR TITLE
feat: add birdseye screen and nav button on home screen

### DIFF
--- a/src/assets/icons/birdseye.svg
+++ b/src/assets/icons/birdseye.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><title>camera-document</title><path d="M21 7V22H3V20H19V7H14.72C14.38 7.6 13.74 8 13 8C13 9.11 12.1 10 11 10H8C6.9 10 6 9.1 6 8V4C6 2.9 6.9 2 8 2H11C12.1 2 13 2.9 13 4C13.74 4 14.38 4.41 14.72 5H19C20.11 5 21 5.89 21 7M6 15H13L11 11H8L6 15Z" /></svg>

--- a/src/navigation/navigationContainer.tsx
+++ b/src/navigation/navigationContainer.tsx
@@ -1,12 +1,14 @@
-import {useColorScheme} from 'react-native';
+import {Button, useColorScheme} from 'react-native';
 
 import EventIcon from '@icons/event.svg';
 import HomeIcon from '@icons/home.svg';
 import VideoIcon from '@icons/video-waveform.svg';
+import BirdseyeIcon from '@icons/birdseye.svg';
 import {createBottomTabNavigator} from '@react-navigation/bottom-tabs';
 import {
   NavigationContainer,
   NavigatorScreenParams,
+  useNavigation,
 } from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 
@@ -15,6 +17,7 @@ import {
   HomeScreen,
   LiveViewScreen,
   OnBoardingScreen,
+  BirdseyeScreen,
 } from '@screens';
 import {useAppDataStore} from '@stores';
 
@@ -22,9 +25,11 @@ import {useAppDataStore} from '@stores';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 //@ts-ignore
 import {colors, hslFunction} from '../../themeColors.js';
+import {useConfig} from '@api';
 
 export type MainStackParamList = {
   Home: undefined;
+  Birdseye: undefined;
   Tabs: NavigatorScreenParams<TabsStackParamList>;
   Onboarding: undefined;
 };
@@ -41,6 +46,7 @@ const TabStack = createBottomTabNavigator<TabsStackParamList>();
 
 const TabNavigator = () => {
   const isDarkMode = useColorScheme() === 'dark';
+
   //TODO: make work with tailwind theme...
   return (
     <TabStack.Navigator
@@ -98,6 +104,8 @@ const TabNavigator = () => {
 };
 
 export const NavigationWrapper = () => {
+  const config = useConfig();
+
   const currentCamera = useAppDataStore(state => state.currentCamera);
   const isDarkMode = useColorScheme() === 'dark';
 
@@ -117,6 +125,24 @@ export const NavigationWrapper = () => {
           options={{
             headerBackTitle: 'Back',
             headerTitle: 'Bird Watcher - Frigate',
+            headerLeft: () => {
+              const nav = useNavigation();
+
+              if (!config.data?.birdseye.enabled) {
+                return null;
+              }
+
+              return (
+                <BirdseyeIcon
+                  height={25}
+                  width={25}
+                  onPress={() => {
+                    nav.navigate('Birdseye');
+                  }}
+                  color="#000"
+                />
+              );
+            },
             headerTintColor: isDarkMode
               ? colors.dark.accent
               : colors.light.accent,
@@ -132,6 +158,13 @@ export const NavigationWrapper = () => {
           }}
         />
         <Stack.Screen name="Onboarding" component={OnBoardingScreen} />
+        <Stack.Screen
+          name="Birdseye"
+          component={BirdseyeScreen}
+          options={{
+            headerBackTitle: 'Home',
+          }}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/navigation/navigationContainer.tsx
+++ b/src/navigation/navigationContainer.tsx
@@ -139,7 +139,8 @@ export const NavigationWrapper = () => {
                   onPress={() => {
                     nav.navigate('Birdseye');
                   }}
-                  color="#000"
+                  fill={tintColor}
+                  fillSecondary={tintColor}
                 />
               );
             },

--- a/src/screens/BirdseyeScreen/BirdseyeScreen.tsx
+++ b/src/screens/BirdseyeScreen/BirdseyeScreen.tsx
@@ -1,0 +1,16 @@
+import {useConfig} from '@api';
+import {BaseText, WebRTCView} from '@components';
+
+export const BirdseyeScreen = () => {
+  const config = useConfig();
+
+  if (config.isLoading) {
+    return <BaseText>Loading ...</BaseText>;
+  }
+
+  if (config.data?.birdseye.enabled) {
+    return <WebRTCView cameraName="birdseye" />;
+  }
+
+  return <BaseText>Birdseye is not enabled</BaseText>;
+};

--- a/src/screens/BirdseyeScreen/index.ts
+++ b/src/screens/BirdseyeScreen/index.ts
@@ -1,0 +1,1 @@
+export * from './BirdseyeScreen';

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -3,3 +3,4 @@ export * from './LiveViewScreen';
 export * from './EventsScreen';
 //
 export * from './onboardingScreen';
+export * from './BirdseyeScreen';


### PR DESCRIPTION
Added the Birdseye camera view screen and navigation via a button in the top left of the Home Screen. 

Icon should be hidden if the Birdseye config is not enabled and shown if it is. This works for me with the config enabled so hoping @billyjacoby can test since his Birdseye is off. 