### PR TITLE
Show live text instead of Unix epoch

### DIFF
--- a/src/components/snapshotCard.tsx
+++ b/src/components/snapshotCard.tsx
@@ -17,6 +17,13 @@ export const SnapshotCard = ({
   const imageWidth = width * 0.97;
   const imageHeight = imageWidth * 0.75;
 
+  // ongoing events have end date of either '1/1/70' or '01/01/1970'
+  const endDate =
+    camEvent?.lastEventEnded.startsWith('1/1/70') ||
+    camEvent?.lastEventEnded.startsWith('01/01/1970')
+      ? 'Current'
+      : camEvent?.lastEventEnded;
+
   return (
     <View className="self-center border border-accent dark:border-accent-dark relative rounded-lg">
       <Image
@@ -39,7 +46,7 @@ export const SnapshotCard = ({
           {!!camEvent.lastEventEnded && (
             <Label>
               <BaseText className="text-xs text-mutedForeground dark:text-mutedForeground-dark">
-                {camEvent.lastEventEnded}
+                {endDate}
               </BaseText>
             </Label>
           )}

--- a/src/screens/EventsScreen/components/EventDetails.tsx
+++ b/src/screens/EventsScreen/components/EventDetails.tsx
@@ -17,6 +17,14 @@ export const EventDetails = ({camEvent}: {camEvent: FrigateEvent}) => {
   // TODO: format minutes here too.
   const eventDuration = Math.round(camEvent.end_time - camEvent.start_time);
 
+  const endTimeValue =
+    endDate.getFullYear() === 1970
+      ? 'Current'
+      : endDate.toLocaleDateString() + ' @ ' + endDate.toLocaleTimeString();
+
+  const durationValue =
+    eventDuration < 0 ? 'Ongoing' : eventDuration + ' seconds';
+
   return (
     <BaseView className="flex-1">
       <BaseText className="self-center text-lg mb-1">Event Details</BaseText>
@@ -30,13 +38,11 @@ export const EventDetails = ({camEvent}: {camEvent: FrigateEvent}) => {
       </Row>
       <Row>
         <BaseText>End Time</BaseText>
-        <BaseText>
-          {endDate.toLocaleDateString() + ' @ ' + endDate.toLocaleTimeString()}
-        </BaseText>
+        <BaseText>{endTimeValue}</BaseText>
       </Row>
       <Row>
         <BaseText>Event Duration</BaseText>
-        <BaseText>{eventDuration} seconds</BaseText>
+        <BaseText>{durationValue}</BaseText>
       </Row>
       <Row>
         <BaseText>Object Label</BaseText>


### PR DESCRIPTION
Show "Ongoing" or "Current" instead of Unix epoch when an event is currently being captured by Frigate. 

![Simulator Screenshot - iPhone 14 - 2023-09-24 at 17 09 01](https://github.com/billyjacoby/bird-watcher/assets/34138267/be6bd2cc-8d7a-4473-a276-eba3f7c2d6ef)
![Simulator Screenshot - iPhone 14 - 2023-09-24 at 17 09 03](https://github.com/billyjacoby/bird-watcher/assets/34138267/0f61fbb8-9c0e-4b2b-ae3a-935e3d5cec8e)
